### PR TITLE
peer: shift async responsibility from PingManager to Brontide

### DIFF
--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -576,7 +576,7 @@ func NewBrontide(cfg Config) *Brontide {
 			eStr := "pong response failure for %s: %v " +
 				"-- disconnecting"
 			p.log.Warnf(eStr, p, err)
-			p.Disconnect(fmt.Errorf(eStr, p, err))
+			go p.Disconnect(fmt.Errorf(eStr, p, err))
 		},
 	})
 

--- a/peer/ping_manager.go
+++ b/peer/ping_manager.go
@@ -131,7 +131,7 @@ func (m *PingManager) pingHandler() {
 				e := errors.New("impossible: new ping" +
 					"in unclean state",
 				)
-				go m.cfg.OnPongFailure(e)
+				m.cfg.OnPongFailure(e)
 
 				return
 			}
@@ -145,7 +145,7 @@ func (m *PingManager) pingHandler() {
 			// Set up our bookkeeping for the new Ping.
 			if err := m.setPingState(pongSize); err != nil {
 
-				go m.cfg.OnPongFailure(err)
+				m.cfg.OnPongFailure(err)
 
 				return
 			}
@@ -159,7 +159,7 @@ func (m *PingManager) pingHandler() {
 				"pong response",
 			)
 
-			go m.cfg.OnPongFailure(e)
+			m.cfg.OnPongFailure(e)
 
 			return
 
@@ -180,7 +180,7 @@ func (m *PingManager) pingHandler() {
 					"not match expected size",
 				)
 
-				go m.cfg.OnPongFailure(e)
+				m.cfg.OnPongFailure(e)
 
 				return
 			}


### PR DESCRIPTION
The creator of the ping manager should have the ability to control the creation of goroutines to satisfy failure requirements. Here we make defining the fork operation the responsibility of the caller (Brontide).